### PR TITLE
Add contact section with socials and CV link

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -121,6 +121,15 @@ section {
   height: 100%;
 }
 
+.contact-list {
+  list-style: none;
+  padding: 0;
+}
+
+.contact-list li {
+  margin-bottom: 0.5rem;
+}
+
 @media (max-width: 600px) {
   nav ul {
     gap: 1rem;

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
     </section>
     <section id="about">
       <h2>About</h2>
-      <p>Brief introduction about yourself. Replace this text with your bio.</p>
+      <p>I'm Lukas Klostermair, an engineer passionate about robotics and software development.</p>
     </section>
     <section id="experience">
       <h2>Experience</h2>
@@ -53,7 +53,12 @@
     </section>
     <section id="contact">
       <h2>Contact</h2>
-      <p>Feel free to reach out via <a href="mailto:you@example.com">email</a>.</p>
+      <ul class="contact-list">
+        <li>Email: <a href="mailto:lukas.klostermair@gmail.com">lukas.klostermair@gmail.com</a></li>
+        <li>GitHub: <a href="https://github.com/lklostermair" target="_blank" rel="noopener">github.com/lklostermair</a></li>
+        <li>LinkedIn: <a href="https://www.linkedin.com/in/lukas-klostermair-09ab61224" target="_blank" rel="noopener">linkedin.com/in/lukas-klostermair-09ab61224</a></li>
+        <li><a href="assets/0020250428_Klostermair_CV.pdf" target="_blank" rel="noopener">Download CV</a></li>
+      </ul>
     </section>
   </main>
   <footer>


### PR DESCRIPTION
## Summary
- Add short about text and contact list with email, GitHub, LinkedIn, and CV download
- Style contact list for cleaner presentation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f037b2a208333b0daf4b33030a505