### PR TITLE
Replace navigation with CV and projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 Static site served via GitHub Pages.
 
 ## Customize
-- Edit profile, publications and projects in `script.js` under the `PROFILE`, `PUBLICATIONS` and `PROJECTS` objects.
+- Update navigation content in `index.html`.
 - Update theme tokens in `styles.css` under the `:root[data-theme="*"]` blocks.
 - Replace `assets/portrait.svg` and social SVGs in `assets/social/`.
-- CV entries are stored in `assets/cv.json`.
+
+ CV and project entries can be added in `script.js` under the `cvData` and `projectData` arrays.
 
 ## Development
 Open `index.html` locally in a browser. Run linters before committing:

--- a/index.html
+++ b/index.html
@@ -47,10 +47,8 @@
 
       <!-- Tabs directly under name (lowercase like the screenshot) -->
       <nav class="top-nav" aria-label="Primary" role="tablist">
-        <button role="tab" id="tab-iprl" aria-controls="panel-iprl" aria-selected="true">iprl</button>
-        <button role="tab" id="tab-news" aria-controls="panel-news" aria-selected="false">news</button>
-        <button role="tab" id="tab-pubs" aria-controls="panel-pubs" aria-selected="false">publications</button>
-        <button role="tab" id="tab-teaching" aria-controls="panel-teaching" aria-selected="false">teaching</button>
+        <button role="tab" id="tab-cv" aria-controls="panel-cv" aria-selected="true">cv</button>
+        <button role="tab" id="tab-projects" aria-controls="panel-projects" aria-selected="false">projects</button>
         <button role="tab" id="tab-contact" aria-controls="panel-contact" aria-selected="false">contact</button>
       </nav>
     </div>
@@ -68,36 +66,18 @@
 
     <!-- Panels area: content swaps here without scrolling -->
     <section class="panels-area">
-      <div id="panel-iprl" role="tabpanel" aria-labelledby="tab-iprl" class="panel active">
-        <h2 class="panel-title">iprl</h2>
-        <p>Lab/initiative content placeholder.</p>
+      <div id="panel-cv" role="tabpanel" aria-labelledby="tab-cv" class="panel active">
+        <h2 class="panel-title">cv</h2>
+        <ul id="cv-list" class="list cv-list"></ul>
       </div>
 
-      <div id="panel-news" role="tabpanel" aria-labelledby="tab-news" class="panel">
-        <h2 class="panel-title">news</h2>
-        <ul class="list">
-          <li>08/2025 — Site refresh with minimal design and in-place tabbed content.</li>
-          <li>06/2025 — Project milestones and new publications coming soon.</li>
-        </ul>
-      </div>
-
-      <div id="panel-pubs" role="tabpanel" aria-labelledby="tab-pubs" class="panel">
-        <h2 class="panel-title">publications</h2>
-        <div class="filter-chips" id="pub-filter" aria-label="Filter publications"></div>
-        <p id="pub-count" aria-live="polite"></p>
-        <ul id="pub-list" class="list"></ul>
-      </div>
-
-      <div id="panel-teaching" role="tabpanel" aria-labelledby="tab-teaching" class="panel">
-        <h2 class="panel-title">teaching</h2>
-        <ul class="list">
-          <li>Guest lectures and workshop topics to be announced.</li>
-        </ul>
+      <div id="panel-projects" role="tabpanel" aria-labelledby="tab-projects" class="panel">
+        <h2 class="panel-title">projects</h2>
+        <ul id="projects-list" class="list projects-list"></ul>
       </div>
 
       <div id="panel-contact" role="tabpanel" aria-labelledby="tab-contact" class="panel">
         <h2 class="panel-title">contact</h2>
-        <p><a id="email" href="mailto:lukas.klostermair@gmail.com" aria-label="Email Lukas">lukas.klostermair@gmail.com</a></p>
         <div class="social-icons" aria-label="Social links">
           <a href="https://github.com/lklostermair" target="_blank" rel="noopener" aria-label="GitHub">
             <img src="assets/social/github.svg" width="24" height="24" alt="">

--- a/script.js
+++ b/script.js
@@ -1,12 +1,35 @@
-// script.js — tabs swap content in-place; pubs demo plumbing
+// script.js — tabs swap content in-place
 // Last updated is shown in footer.
 const updated = document.getElementById('updated');
 if (updated) updated.textContent = new Date(document.lastModified).toLocaleDateString();
 
 // --- Tabs (top-nav) ---
-const tablist = document.querySelector('.top-nav[role="tablist"]');
 const tabs = [...document.querySelectorAll('.top-nav [role="tab"]')];
 const panels = [...document.querySelectorAll('[role="tabpanel"]')];
+
+// --- Data placeholders ---
+// Add your CV entries here. Each item requires:
+// image, timeframe, position, company, description
+const cvData = [
+  /* {
+    image: 'assets/companies/company.png',
+    timeframe: '2020-2022',
+    position: 'Job Title',
+    company: 'Company Name',
+    description: 'Short description of your role.'
+  } */
+];
+
+// Add your projects here. Each item requires:
+// image, timeframe, name, description
+const projectData = [
+  /* {
+    image: 'assets/projects/project.png',
+    timeframe: '2024',
+    name: 'Project Name',
+    description: 'Short description of the project.'
+  } */
+];
 
 function activateTab(tab, pushHash = true) {
   // aria state
@@ -15,7 +38,7 @@ function activateTab(tab, pushHash = true) {
   panels.forEach(p => p.classList.toggle('active', p.id === tab.getAttribute('aria-controls')));
   // URL state (no scroll)
   if (pushHash) {
-    const hash = tab.id.replace('tab-',''); // e.g., iprl
+    const hash = tab.id.replace('tab-',''); // e.g., cv
     history.replaceState(null, '', `#${hash}`);
   }
 }
@@ -44,7 +67,7 @@ tabs.forEach(tab => {
   });
 });
 
-// Hash deep-link support (e.g., /#publications)
+// Hash deep-link support (e.g., /#projects)
 function initFromHash() {
   const raw = (location.hash || '').replace('#','').trim();
   const valid = raw && getTabByHash(raw);
@@ -53,86 +76,45 @@ function initFromHash() {
 window.addEventListener('hashchange', initFromHash);
 initFromHash();
 
-// --- Publications demo data + filter wiring (optional; safe to remove if unused) ---
-const PUBLICATIONS = [
-  // Example entries:
-  // { title: "Paper Title", authors: "A. Author, B. Author", venue: "Conf 2025", year: 2025, link: "#", tags: ["grasping","perception"] }
-];
+// --- Render helpers ---
+const cvList = document.getElementById('cv-list');
+const projectsList = document.getElementById('projects-list');
 
-const pubList = document.getElementById('pub-list');
-const pubFilter = document.getElementById('pub-filter');
-const pubCount = document.getElementById('pub-count');
-
-function uniqueTags() {
-  const set = new Set();
-  PUBLICATIONS.forEach(p => (p.tags || []).forEach(t => set.add(t)));
-  return Array.from(set).sort();
-}
-
-function parseTagsFromUrl() {
-  const params = new URLSearchParams(location.search);
-  const tags = params.get('tags');
-  return tags ? tags.split(',').map(s => s.trim()).filter(Boolean) : [];
-}
-
-function setTagsInUrl(tags) {
-  const params = new URLSearchParams(location.search);
-  if (tags.length) params.set('tags', tags.join(','));
-  else params.delete('tags');
-  history.replaceState(null, '', `${location.pathname}${params.toString() ? '?' + params.toString() : ''}${location.hash}`);
-}
-
-function renderFilters(activeTags) {
-  pubFilter.innerHTML = '';
-  const allBtn = document.createElement('button');
-  allBtn.textContent = 'All';
-  allBtn.setAttribute('aria-pressed', String(activeTags.length === 0));
-  allBtn.addEventListener('click', () => {
-    setTagsInUrl([]); renderFilters([]); renderPubs([]);
+function renderCV() {
+  if (!cvList) return;
+  const frag = document.createDocumentFragment();
+  cvData.forEach(item => {
+    const li = document.createElement('li');
+    li.className = 'cv-item';
+    li.innerHTML = `
+      <img src="${item.image}" alt="">
+      <div class="cv-details">
+        <div><strong>${item.position}</strong> at ${item.company}</div>
+        <div class="cv-timeframe">${item.timeframe}</div>
+        <p>${item.description}</p>
+      </div>
+    `;
+    frag.appendChild(li);
   });
-  pubFilter.appendChild(allBtn);
+  cvList.appendChild(frag);
+}
 
-  uniqueTags().forEach(tag => {
-    const b = document.createElement('button');
-    b.textContent = tag;
-    b.setAttribute('aria-pressed', String(activeTags.includes(tag)));
-    b.addEventListener('click', () => {
-      const next = activeTags.includes(tag) ? activeTags.filter(t => t !== tag) : [...activeTags, tag];
-      setTagsInUrl(next); renderFilters(next); renderPubs(next);
-    });
-    pubFilter.appendChild(b);
+function renderProjects() {
+  if (!projectsList) return;
+  const frag = document.createDocumentFragment();
+  projectData.forEach(item => {
+    const li = document.createElement('li');
+    li.className = 'project-item';
+    li.innerHTML = `
+      <img src="${item.image}" alt="">
+      <div><strong>${item.name}</strong> <span class="project-timeframe">${item.timeframe}</span></div>
+      <p>${item.description}</p>
+    `;
+    frag.appendChild(li);
   });
+  projectsList.appendChild(frag);
 }
 
-function renderPubs(activeTags) {
-  const items = !activeTags.length
-    ? PUBLICATIONS
-    : PUBLICATIONS.filter(p => (p.tags || []).every(t => activeTags.includes(t)));
-  pubList.innerHTML = items.map(p => `
-    <li>
-      <strong><a href="${p.link || '#'}" target="_blank" rel="noopener">${p.title}</a></strong><br>
-      <span>${p.authors}</span> — <em>${p.venue}</em> (${p.year})
-    </li>
-  `).join('');
-  if (pubCount) pubCount.textContent = `${items.length} result${items.length === 1 ? '' : 's'}`;
-}
+renderCV();
+renderProjects();
 
-// Initialize publications UI when its panel first becomes active
-let pubsInitialized = false;
-function initPublicationsIfNeeded() {
-  if (pubsInitialized) return;
-  pubsInitialized = true;
-  const active = parseTagsFromUrl();
-  renderFilters(active);
-  renderPubs(active);
-}
-
-// Observe panel activation to lazily init pubs
-const observer = new MutationObserver(() => {
-  const pubsPanel = document.getElementById('panel-pubs');
-  if (pubsPanel && pubsPanel.classList.contains('active')) initPublicationsIfNeeded();
-});
-observer.observe(document.body, { attributes: true, subtree: true, attributeFilter: ['class'] });
-
-// If deep-linked to publications, initialize immediately
-if ((location.hash || '').includes('pubs')) initPublicationsIfNeeded();

--- a/styles.css
+++ b/styles.css
@@ -94,6 +94,16 @@ header.hero{
 .list{list-style:none;margin:0 auto 1rem;padding:0;max-width:760px;text-align:left}
 .list li{padding:.5rem 0;border-bottom:1px solid var(--line)}
 
+/* CV list */
+.cv-list li{display:flex;gap:1rem;align-items:flex-start}
+.cv-list img{width:48px;height:48px;object-fit:contain;border-radius:4px}
+.cv-timeframe{font-size:.9rem;color:var(--muted)}
+
+/* Projects list with large images */
+.projects-list li{display:flex;flex-direction:column;gap:.5rem;margin-bottom:1rem}
+.projects-list img{width:100%;border-radius:8px}
+.project-timeframe{font-size:.9rem;color:var(--muted)}
+
 /* Publications filter chips */
 .filter-chips{display:flex;flex-wrap:wrap;gap:.5rem;justify-content:center;margin:.5rem 0 1rem}
 .filter-chips button{


### PR DESCRIPTION
## Summary
- Provide empty `cvData` and `projectData` arrays in `script.js` for CV and project items
- Display lists for CV and projects with styling and remove explicit email address from contact panel
- Document where to add entries in README

## Testing
- `npm run lint` *(fails: 45 errors in styles.css)*

------
https://chatgpt.com/codex/tasks/task_e_68a70fa332e88333a6ae92ca74ac179a