### PR TITLE
Fix CV loading, use generic font, and repair Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,7 +20,7 @@ jobs:
       - if: github.event_name == 'push'
         run: |
           mkdir _site
-          cp -R . _site
+          rsync -av --exclude=_site --exclude=.git --exclude=node_modules . _site
       - if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v3
         with:

--- a/index.html
+++ b/index.html
@@ -17,12 +17,9 @@
   <meta name="twitter:card" content="summary"/>
   <meta name="theme-color" content="#ffffff"/>
 
-  <!-- Preload custom font -->
-  <link rel="preload" href="assets/fonts/DinaRemasterCollection.ttc" as="font" type="font/ttc" crossorigin>
-
   <!-- Tiny critical CSS (page still uses styles.css for everything) -->
   <style>
-    body{margin:0;font-family:'Dina',monospace;line-height:1.7}
+    body{margin:0;font-family:'Courier New',monospace;line-height:1.7}
     main{max-width:960px;margin:auto;padding:0 1rem}
     header.hero{display:flex;flex-direction:column;align-items:center;text-align:center;gap:2rem;padding:4rem 1rem 2rem;max-width:760px;margin:0 auto}
     .portrait{flex:none;width:320px;height:320px;border-radius:50%;overflow:hidden}

--- a/script.js
+++ b/script.js
@@ -129,17 +129,12 @@ function mapCV(data) {
 
 async function loadCV() {
   try {
-    const res = await fetch('assets/cv.json');
+    const url = new URL('./assets/cv.json', import.meta.url);
+    const res = await fetch(url);
     const data = await res.json();
     renderCV(mapCV(data));
   } catch (err) {
-    console.error('CV fetch failed, attempting import', err);
-    try {
-      const mod = await import('./assets/cv.json', { with: { type: 'json' } });
-      renderCV(mapCV(mod.default));
-    } catch (err2) {
-      console.error('CV load failed', err2);
-    }
+    console.error('CV load failed', err);
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,15 +1,6 @@
 /* styles.css — single light theme, centered + in-place panels */
 /* stylelint-disable */
 
-/* === Custom font face === */
-@font-face {
-  font-family: 'Dina';
-  src: url('assets/fonts/DinaRemasterCollection.ttc') format('truetype-collection');
-  font-weight: normal;
-  font-style: normal;
-  font-display: swap;
-}
-
 /* Tokens */
 :root{
   --bg:#ffffff;
@@ -26,7 +17,7 @@
 html{scroll-behavior:smooth}
 body{
   margin:0;
-  font-family:'Dina', monospace;
+  font-family:'Courier New', monospace;
   font-size:16px;
   line-height:1.7;
   background:var(--bg);


### PR DESCRIPTION
## Summary
- remove custom font preload and use generic Courier New font
- fetch CV data with stable relative URL
- copy site files with rsync to fix Pages build

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a71ce264d48333a13fc49b30b82795